### PR TITLE
Object Item

### DIFF
--- a/src/Resource/ObjectCollection.php
+++ b/src/Resource/ObjectCollection.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace Diaclone\Resource;
+
+use Diaclone\Transformer\AbstractTransformer;
+
+class ObjectCollection extends AbstractResource
+{
+    public function transform(AbstractTransformer $transformer)
+    {
+        $items = $transformer->getPropertyValue($this->getData(), $this->getPropertyName());
+
+        if (empty($items)) {
+            return [];
+        }
+
+        $response = [];
+
+        foreach ($items as $item) {
+            if ($transformedItem = $transformer->transform(new ObjectItem($item, '', $this->fieldMap))) {
+                $response[] = $transformedItem;
+            }
+        }
+
+        return $response;
+    }
+
+    public function untransform(AbstractTransformer $transformer)
+    {
+        $data = $this->getData();
+        if (empty($data)) {
+            return $data;
+        }
+
+        $response = [];
+        foreach ($data as $item) {
+            $response[] = $transformer->untransform(new ObjectItem($item));
+        }
+
+        return $response;
+    }
+}

--- a/src/Resource/ObjectItem.php
+++ b/src/Resource/ObjectItem.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types = 1);
+
+namespace Diaclone\Resource;
+
+use Diaclone\Exception\MalformedInputException;
+use Diaclone\Exception\TransformException;
+use Diaclone\Exception\UnrecognizedInputException;
+use Diaclone\Transformer\AbstractTransformer;
+use Exception;
+
+class ObjectItem extends Item
+{
+    public function untransform(AbstractTransformer $transformer)
+    {
+        if ($this->getData() === null) {
+            return null;
+        }
+
+        $unrecognizedFields = [];
+        $malformedFields = [];
+
+        $className = $transformer->getObjectClass();
+        $response = new $className();
+
+        $mapping = array_flip($transformer->getMappedProperties());
+
+        foreach ($this->getData() as $incomingProperty => $data) {
+            if (empty($mapping[$incomingProperty])) {
+                $unrecognizedFields[] = $incomingProperty;
+                continue;
+            }
+            $property = $mapping[$incomingProperty];
+
+            $propertyTransformerClass = $transformer->getPropertyTransformer($property);
+            /** @var AbstractTransformer $propertyTransformer */
+            $propertyTransformer = new $propertyTransformerClass();
+
+            $dataTypeClass = $this->getDataType($transformer, $property);
+            $dataType = new $dataTypeClass($data, $property);
+
+            if ($propertyTransformer->allowUntransform($dataType)) {
+                try {
+                    $this->setPropertyValue($response, $property, $propertyTransformer->untransform($dataType));
+                } catch (UnrecognizedInputException $e) {
+                    throw $e;
+                } catch (Exception $e) {
+                    $malformedFields[] = $incomingProperty;
+                }
+            }
+        }
+
+        if (! empty($unrecognizedFields)) {
+            throw new UnrecognizedInputException($unrecognizedFields, $transformer);
+        }
+
+        if (! empty($malformedFields)) {
+            throw new MalformedInputException($malformedFields);
+        }
+
+        return $response;
+    }
+
+    protected function setPropertyValue($object, $property, $value)
+    {
+        // convert property to camelCase
+        $setter = 'set' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $property)));
+        if (method_exists($object, $setter)) {
+            $object->$setter($value);
+
+            return;
+        }
+
+        if (property_exists($object, $property)) {
+            $object->$property = $value;
+
+            return;
+        }
+
+        throw new TransformException(sprintf('You must either create a %s method in %s or add a public property', $setter, get_class($object), $property));
+    }
+
+    protected function getDataType($transformer, string $property): string
+    {
+        $rp = new \ReflectionProperty($transformer, 'dataTypes');
+        $rp->setAccessible(true);
+        $types = $rp->getValue($transformer);
+        if (empty($types[$property])) {
+            return ObjectItem::class;
+        }
+        if (Collection::class === $types[$property]) {
+            return ObjectCollection::class;
+        }
+
+        return $types[$property];
+    }
+}

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -3,9 +3,15 @@ declare(strict_types = 1);
 
 namespace Diaclone\Resource;
 
+use Diaclone\Transformer\AbstractTransformer;
+
 interface ResourceInterface
 {
     public function getData();
 
     public function getPropertyName();
+
+    public function transform(AbstractTransformer $transformer);
+
+    public function untransform(AbstractTransformer $transformer);
 }

--- a/src/Transformer/AbstractObjectTransformer.php
+++ b/src/Transformer/AbstractObjectTransformer.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Diaclone\Transformer;
+
+use Diaclone\Resource\ResourceInterface;
+
+abstract class AbstractObjectTransformer extends AbstractTransformer
+{
+    abstract public function getObjectClass(): string;
+
+    public function toObject(ResourceInterface $resource)
+    {
+        return $resource->untransform($this);
+    }
+
+    public function toArray(ResourceInterface $resource)
+    {
+        return $resource->transform($this);
+    }
+}

--- a/src/Transformer/AbstractTransformer.php
+++ b/src/Transformer/AbstractTransformer.php
@@ -100,4 +100,5 @@ abstract class AbstractTransformer
     {
         return $resource->untransform($this);
     }
+
 }

--- a/tests/unit/ObjectTransformCest.php
+++ b/tests/unit/ObjectTransformCest.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types = 1);
+
+namespace Test\Unit;
+
+use Diaclone\Resource\ObjectCollection;
+use Diaclone\Resource\ObjectItem;
+use Test\Unit\Support\Transformers\PersonObjectTransformer;
+use UnitTester;
+use Test\Unit\Support\Entities\Person;
+
+class ObjectTransformCest
+{
+    public function testToArray(UnitTester $I)
+    {
+        $friends = [
+            new Person('Paul', 'Real estate novelist'),
+            new Person('John', 'Bartender'),
+            new Person('Davy', 'Sailor'),
+            new Person('Elizabeth', 'Waitress'),
+        ];
+
+        $person = new Person('Bill', 'Piano Man', $friends);
+        $resource = new ObjectItem($person);
+        $output = (new PersonObjectTransformer())->toArray($resource);
+        $expected = [
+            'name' => 'My name is Bill',
+            'age' => 42,
+            'pigLatin' => 'Ymay amenay isyay Illbay',
+            'occupation' => [
+                'name' => 'Piano Man',
+                'startDate' => '2017-01-01T10:10:10+0000',
+            ],
+            'friends' => [
+                [
+                    'name' => 'My name is Paul',
+                    'age' => 42,
+                    'pigLatin' => 'Ymay amenay isyay Aulpay',
+                    'occupation' => [
+                        'name' => 'Real estate novelist',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                    'friends' => [],
+                ],
+                [
+                    'name' => 'My name is John',
+                    'age' => 42,
+                    'pigLatin' => 'Ymay amenay isyay Ohnjay',
+                    'occupation' => [
+                        'name' => 'Bartender',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                    'friends' => [],
+                ],
+                [
+                    'name' => 'My name is Davy',
+                    'age' => 42,
+                    'pigLatin' => 'Ymay amenay isyay Avyday',
+                    'occupation' => [
+                        'name' => 'Sailor',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                    'friends' => [],
+                ],
+                [
+                    'name' => 'My name is Elizabeth',
+                    'age' => 42,
+                    'pigLatin' => 'Ymay amenay isyay Elizabethyay',
+                    'occupation' => [
+                        'name' => 'Waitress',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                    'friends' => [],
+                ],
+            ],
+        ];
+        $I->assertEquals($expected, $output);
+    }
+
+    public function testToObject(UnitTester $I)
+    {
+        $payload = [
+            'name' => 'Bill',
+            'age' => 42,
+            'occupation' => [
+                'name' => 'Piano Man',
+            ],
+            'friends' => [
+                [
+                    'name' => 'Paul',
+                    'age' => 42,
+                    'occupation' => [
+                        'name' => 'Real estate novelist',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                ],
+                [
+                    'name' => 'John',
+                    'age' => 42,
+                    'occupation' => [
+                        'name' => 'Bartender',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                ],
+                [
+                    'name' => 'Davy',
+                    'age' => 42,
+                    'occupation' => [
+                        'name' => 'Sailor',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                ],
+                [
+                    'name' => 'Elizabeth',
+                    'age' => 42,
+                    'occupation' => [
+                        'name' => 'Waitress',
+                        'startDate' => '2017-01-01T10:10:10+0000',
+                    ],
+                ],
+            ],
+        ];
+        $resource = new ObjectItem($payload);
+        $output = (new PersonObjectTransformer())->toObject($resource);
+        $friends = [
+            new Person('Paul', 'Real estate novelist'),
+            new Person('John', 'Bartender'),
+            new Person('Davy', 'Sailor'),
+            new Person('Elizabeth', 'Waitress'),
+        ];
+
+        $expected = new Person('Bill', 'Piano Man', $friends);
+        $I->assertEquals($expected, $output);
+    }
+
+    public function testTransformationCollectionAll(UnitTester $I)
+    {
+        $friends = [
+            new Person('Paul', 'Real estate novelist'),
+            new Person('John', 'Bartender'),
+            new Person('Davy', 'Sailor'),
+            new Person('Elizabeth', 'Waitress'),
+        ];
+
+        $resource = new ObjectCollection($friends);
+        $output = (new PersonObjectTransformer())->toArray($resource);
+        $expected = [
+            [
+                'name' => 'My name is Paul',
+                'age' => 42,
+                'pigLatin' => 'Ymay amenay isyay Aulpay',
+                'occupation' => [
+                    'name' => 'Real estate novelist',
+                    'startDate' => '2017-01-01T10:10:10+0000',
+                ],
+                'friends' => [],
+            ],
+            [
+                'name' => 'My name is John',
+                'age' => 42,
+                'pigLatin' => 'Ymay amenay isyay Ohnjay',
+                'occupation' => [
+                    'name' => 'Bartender',
+                    'startDate' => '2017-01-01T10:10:10+0000',
+                ],
+                'friends' => [],
+            ],
+            [
+                'name' => 'My name is Davy',
+                'age' => 42,
+                'pigLatin' => 'Ymay amenay isyay Avyday',
+                'occupation' => [
+                    'name' => 'Sailor',
+                    'startDate' => '2017-01-01T10:10:10+0000',
+                ],
+                'friends' => [],
+            ],
+            [
+                'name' => 'My name is Elizabeth',
+                'age' => 42,
+                'pigLatin' => 'Ymay amenay isyay Elizabethyay',
+                'occupation' => [
+                    'name' => 'Waitress',
+                    'startDate' => '2017-01-01T10:10:10+0000',
+                ],
+                'friends' => [],
+            ],
+        ];
+        $I->assertEquals($expected, $output);
+    }
+}

--- a/tests/unit/SerializerNullCest.php
+++ b/tests/unit/SerializerNullCest.php
@@ -72,7 +72,7 @@ class SerializerNullCest
                 'pigLatin'   => 'Ymay amenay isyay Illbay',
                 'occupation' => [
                     'name'      => 'Piano Man',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [
                     [
@@ -81,7 +81,7 @@ class SerializerNullCest
                         'pigLatin'   => 'Ymay amenay isyay Aulpay',
                         'occupation' => [
                             'name'      => 'Real estate novelist',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -91,7 +91,7 @@ class SerializerNullCest
                         'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                         'occupation' => [
                             'name'      => 'Bartender',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],

--- a/tests/unit/Support/Entities/Occupation.php
+++ b/tests/unit/Support/Entities/Occupation.php
@@ -4,17 +4,18 @@ declare(strict_types = 1);
 namespace Test\Unit\Support\Entities;
 
 use DateTime;
+use DateTimeZone;
 
 class Occupation
 {
     protected $name;
     protected $startDate;
 
-    public function __construct(string $name, string $startDate = null)
+    public function __construct(string $name = null, string $startDate = null)
     {
         $this->name = $name;
-        $this->startDate = $startDate ?: '2017-01-01 10:10:10';
-        //$this->startDate = $startDate ?: (new DateTime())->format('Y-m-d H:i:s');
+        $startDate = $startDate ?: '2017-01-01 10:10:10';
+        $this->startDate = new DateTime($startDate, new DateTimeZone("UTC"));
     }
 
     public function getName()
@@ -22,8 +23,18 @@ class Occupation
         return $this->name;
     }
 
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+
     public function getStartDate()
     {
         return $this->startDate;
+    }
+
+    public function setStartDate(DateTime $startDate)
+    {
+        $this->startDate = $startDate;
     }
 }

--- a/tests/unit/Support/Entities/Person.php
+++ b/tests/unit/Support/Entities/Person.php
@@ -7,24 +7,37 @@ class Person
 {
     public $my_job;
 
+    protected $age = 42;
     protected $friends;
     protected $name;
 
-    public function __construct($name, $occupation, array $friends = [])
+    public function __construct(string $name = null, string $occupation = null, array $friends = [])
     {
         $this->friends = $friends;
         $this->name = $name;
-        $this->my_job = new Occupation($occupation);
+        if ($occupation) {
+            $this->my_job = new Occupation($occupation);
+        }
     }
 
     public function getAge()
     {
-        return 42;
+        return $this->age;
+    }
+
+    public function setAge(int $age)
+    {
+        $this->age = $age;
     }
 
     public function getName()
     {
         return 'My name is ' . $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
     }
 
     public function getNunya()
@@ -35,5 +48,10 @@ class Person
     public function getMyFriends()
     {
         return $this->friends;
+    }
+
+    public function setMyFriends(array $friends)
+    {
+        $this->friends = $friends;
     }
 }

--- a/tests/unit/Support/Transformers/OccupationArrayTransformer.php
+++ b/tests/unit/Support/Transformers/OccupationArrayTransformer.php
@@ -6,14 +6,10 @@ namespace Test\Unit\Support\Transformers;
 use Diaclone\Transformer\AbstractTransformer;
 use Diaclone\Transformer\DateTimeIso8601Transformer;
 
-class OccupationTransformer extends AbstractTransformer
+class OccupationArrayTransformer extends AbstractTransformer
 {
     protected static $mappedProperties = [
         'name'       => 'name',
         'start_date' => 'startDate',
-    ];
-
-    protected static $transformers = [
-        'start_date' => DateTimeIso8601Transformer::class,
     ];
 }

--- a/tests/unit/Support/Transformers/OccupationObjectTransformer.php
+++ b/tests/unit/Support/Transformers/OccupationObjectTransformer.php
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace Test\Unit\Support\Transformers;
 
-use Diaclone\Transformer\AbstractTransformer;
+use Diaclone\Transformer\AbstractObjectTransformer;
 use Diaclone\Transformer\DateTimeIso8601Transformer;
+use Test\Unit\Support\Entities\Occupation;
 
-class OccupationTransformer extends AbstractTransformer
+class OccupationObjectTransformer extends AbstractObjectTransformer
 {
     protected static $mappedProperties = [
         'name'       => 'name',
@@ -16,4 +17,9 @@ class OccupationTransformer extends AbstractTransformer
     protected static $transformers = [
         'start_date' => DateTimeIso8601Transformer::class,
     ];
+
+    public function getObjectClass(): string
+    {
+        return Occupation::class;
+    }
 }

--- a/tests/unit/Support/Transformers/PersonArrayTransformer.php
+++ b/tests/unit/Support/Transformers/PersonArrayTransformer.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types = 1);
+
+namespace Test\Unit\Support\Transformers;
+
+use Diaclone\Resource\Collection;
+use Diaclone\Transformer\AbstractTransformer;
+use Diaclone\Transformer\IntegerTransformer;
+
+class PersonArrayTransformer extends AbstractTransformer
+{
+    protected static $mappedProperties = [
+        'name'       => 'name',
+        'age'        => 'age',
+        'pigLatin'   => 'pigLatin',
+        'my_job'     => 'occupation',
+        'my_friends' => 'friends',
+    ];
+
+    protected static $transformers = [
+        'age'        => IntegerTransformer::class,
+        'my_job'     => OccupationArrayTransformer::class,
+        'my_friends' => PersonArrayTransformer::class,
+        'pigLatin'   => PigLatinTransformer::class,
+    ];
+
+    protected static $dataTypes = [
+        'my_friends' => Collection::class,
+    ];
+}

--- a/tests/unit/Support/Transformers/PersonObjectTransformer.php
+++ b/tests/unit/Support/Transformers/PersonObjectTransformer.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace Test\Unit\Support\Transformers;
+
+use Diaclone\Resource\ObjectCollection;
+use Diaclone\Transformer\AbstractObjectTransformer;
+use Diaclone\Transformer\IntegerTransformer;
+use Test\Unit\Support\Entities\Person;
+
+class PersonObjectTransformer extends AbstractObjectTransformer
+{
+    protected static $mappedProperties = [
+        'name'       => 'name',
+        'age'        => 'age',
+        'pigLatin'   => 'pigLatin',
+        'my_job'     => 'occupation',
+        'my_friends' => 'friends',
+    ];
+
+    protected static $transformers = [
+        'age'        => IntegerTransformer::class,
+        'my_job'     => OccupationObjectTransformer::class,
+        'my_friends' => PersonObjectTransformer::class,
+        'pigLatin'   => PigLatinTransformer::class,
+    ];
+
+    protected static $dataTypes = [
+        'my_friends' => ObjectCollection::class,
+    ];
+
+    public function getObjectClass(): string
+    {
+        return Person::class;
+    }
+}

--- a/tests/unit/TransformCest.php
+++ b/tests/unit/TransformCest.php
@@ -3,12 +3,13 @@ declare(strict_types = 1);
 
 namespace Test\Unit;
 
-use UnitTester;
 use Diaclone\Resource\Collection;
 use Diaclone\Resource\FieldMap;
 use Diaclone\TransformService;
+use Test\Unit\Support\Transformers\PersonArrayTransformer;
 use Test\Unit\Support\Entities\Person;
 use Test\Unit\Support\Transformers\PersonTransformer;
+use UnitTester;
 
 class TransformCest
 {
@@ -29,7 +30,7 @@ class TransformCest
                 'pigLatin'   => 'Ymay amenay isyay Illbay',
                 'occupation' => [
                     'name'      => 'Piano Man',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [
                     [
@@ -38,7 +39,7 @@ class TransformCest
                         'pigLatin'   => 'Ymay amenay isyay Aulpay',
                         'occupation' => [
                             'name'      => 'Real estate novelist',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -48,7 +49,7 @@ class TransformCest
                         'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                         'occupation' => [
                             'name'      => 'Bartender',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -58,7 +59,7 @@ class TransformCest
                         'pigLatin'   => 'Ymay amenay isyay Avyday',
                         'occupation' => [
                             'name'      => 'Sailor',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -68,7 +69,7 @@ class TransformCest
                         'pigLatin'   => 'Ymay amenay isyay Elizabethyay',
                         'occupation' => [
                             'name'      => 'Waitress',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -92,7 +93,7 @@ class TransformCest
                     'age'        => 42,
                     'occupation' => [
                         'name'      => 'Real estate novelist',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
@@ -100,7 +101,7 @@ class TransformCest
                     'age'        => 42,
                     'occupation' => [
                         'name'      => 'Bartender',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
@@ -108,7 +109,7 @@ class TransformCest
                     'age'        => 42,
                     'occupation' => [
                         'name'      => 'Sailor',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
@@ -116,12 +117,12 @@ class TransformCest
                     'age'        => 42,
                     'occupation' => [
                         'name'      => 'Waitress',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
             ],
         ];
-        $output = (new TransformService())->untransform($payload, new PersonTransformer());
+        $output = (new TransformService())->untransform($payload, new PersonArrayTransformer());
 
         $expected = [
             'name'       => 'My name is Bill',
@@ -135,7 +136,7 @@ class TransformCest
                     'age'    => 42,
                     'my_job' => [
                         'name'       => 'Real estate novelist',
-                        'start_date' => '2017-01-01 10:10:10',
+                        'start_date' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
@@ -143,7 +144,7 @@ class TransformCest
                     'age'    => 42,
                     'my_job' => [
                         'name'       => 'Bartender',
-                        'start_date' => '2017-01-01 10:10:10',
+                        'start_date' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
@@ -151,7 +152,7 @@ class TransformCest
                     'age'    => 42,
                     'my_job' => [
                         'name'       => 'Sailor',
-                        'start_date' => '2017-01-01 10:10:10',
+                        'start_date' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
@@ -159,7 +160,7 @@ class TransformCest
                     'age'    => 42,
                     'my_job' => [
                         'name'       => 'Waitress',
-                        'start_date' => '2017-01-01 10:10:10',
+                        'start_date' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
             ],
@@ -176,7 +177,7 @@ class TransformCest
             'pigLatin'   => 'Ymay amenay isyay Illbay',
             'occupation' => [
                 'name'      => 'Piano Man',
-                'startDate' => '2017-01-01 10:10:10',
+                'startDate' => '2017-01-01T10:10:10+0000',
             ],
             'friends'    => [],
         ];
@@ -202,7 +203,7 @@ class TransformCest
                     'pigLatin'   => 'Ymay amenay isyay Aulpay',
                     'occupation' => [
                         'name'      => 'Real estate novelist',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -212,7 +213,7 @@ class TransformCest
                     'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                     'occupation' => [
                         'name'      => 'Bartender',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -222,7 +223,7 @@ class TransformCest
                     'pigLatin'   => 'Ymay amenay isyay Avyday',
                     'occupation' => [
                         'name'      => 'Sailor',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -232,7 +233,7 @@ class TransformCest
                     'pigLatin'   => 'Ymay amenay isyay Elizabethyay',
                     'occupation' => [
                         'name'      => 'Waitress',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -258,7 +259,7 @@ class TransformCest
                 'pigLatin'   => 'Ymay amenay isyay Aulpay',
                 'occupation' => [
                     'name'      => 'Real estate novelist',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],
@@ -268,7 +269,7 @@ class TransformCest
                 'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                 'occupation' => [
                     'name'      => 'Bartender',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],
@@ -278,7 +279,7 @@ class TransformCest
                 'pigLatin'   => 'Ymay amenay isyay Avyday',
                 'occupation' => [
                     'name'      => 'Sailor',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],
@@ -288,7 +289,7 @@ class TransformCest
                 'pigLatin'   => 'Ymay amenay isyay Elizabethyay',
                 'occupation' => [
                     'name'      => 'Waitress',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],
@@ -315,28 +316,28 @@ class TransformCest
                     'name'       => 'My name is Paul',
                     'occupation' => [
                         'name'      => 'Real estate novelist',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
                     'name'       => 'My name is John',
                     'occupation' => [
                         'name'      => 'Bartender',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
                     'name'       => 'My name is Davy',
                     'occupation' => [
                         'name'      => 'Sailor',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
                 [
                     'name'       => 'My name is Elizabeth',
                     'occupation' => [
                         'name'      => 'Waitress',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                 ],
             ],

--- a/tests/unit/TransformNullCest.php
+++ b/tests/unit/TransformNullCest.php
@@ -43,7 +43,7 @@ class TransformNullCest
             'pigLatin'   => 'Ymay amenay isyay Illbay',
             'occupation' => [
                 'name'      => 'Piano Man',
-                'startDate' => '2017-01-01 10:10:10',
+                'startDate' => '2017-01-01T10:10:10+0000',
             ],
             'friends'    => [
                 [
@@ -52,7 +52,7 @@ class TransformNullCest
                     'pigLatin'   => 'Ymay amenay isyay Aulpay',
                     'occupation' => [
                         'name'      => 'Real estate novelist',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -62,7 +62,7 @@ class TransformNullCest
                     'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                     'occupation' => [
                         'name'      => 'Bartender',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],

--- a/tests/unit/TransformToJsonCest.php
+++ b/tests/unit/TransformToJsonCest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Test\Unit;
 
+use Test\Unit\Support\Transformers\PersonArrayTransformer;
 use UnitTester;
 use Diaclone\Resource\Collection;
 use Diaclone\Serializer\SimpleJsonSerializer;
@@ -31,7 +32,7 @@ class TransformToJsonCest
                 'pigLatin'   => 'Ymay amenay isyay Illbay',
                 'occupation' => [
                     'name'      => 'Piano Man',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [
                     [
@@ -40,7 +41,7 @@ class TransformToJsonCest
                         'pigLatin'   => 'Ymay amenay isyay Aulpay',
                         'occupation' => [
                             'name'      => 'Real estate novelist',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -50,7 +51,7 @@ class TransformToJsonCest
                         'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                         'occupation' => [
                             'name'      => 'Bartender',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -60,7 +61,7 @@ class TransformToJsonCest
                         'pigLatin'   => 'Ymay amenay isyay Avyday',
                         'occupation' => [
                             'name'      => 'Sailor',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -70,7 +71,7 @@ class TransformToJsonCest
                         'pigLatin'   => 'Ymay amenay isyay Elizabethyay',
                         'occupation' => [
                             'name'      => 'Waitress',
-                            'startDate' => '2017-01-01 10:10:10',
+                            'startDate' => '2017-01-01T10:10:10+0000',
                         ],
                         'friends'    => [],
                     ],
@@ -126,7 +127,7 @@ class TransformToJsonCest
             ],
         ];
 
-        $output = (new TransformService(new SimpleJsonSerializer()))->untransform($payload, new PersonTransformer());
+        $output = (new TransformService(new SimpleJsonSerializer()))->untransform($payload, new PersonArrayTransformer());
 
         $expected = [
             'name'       => 'My name is Bill',
@@ -184,7 +185,7 @@ class TransformToJsonCest
             'pigLatin'   => 'Ymay amenay isyay Illbay',
             'occupation' => [
                 'name'      => 'Piano Man',
-                'startDate' => '2017-01-01 10:10:10',
+                'startDate' => '2017-01-01T10:10:10+0000',
             ],
             'friends'    => [],
         ];
@@ -212,7 +213,7 @@ class TransformToJsonCest
                     'pigLatin'   => 'Ymay amenay isyay Aulpay',
                     'occupation' => [
                         'name'      => 'Real estate novelist',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -222,7 +223,7 @@ class TransformToJsonCest
                     'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                     'occupation' => [
                         'name'      => 'Bartender',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -232,7 +233,7 @@ class TransformToJsonCest
                     'pigLatin'   => 'Ymay amenay isyay Avyday',
                     'occupation' => [
                         'name'      => 'Sailor',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -242,7 +243,7 @@ class TransformToJsonCest
                     'pigLatin'   => 'Ymay amenay isyay Elizabethyay',
                     'occupation' => [
                         'name'      => 'Waitress',
-                        'startDate' => '2017-01-01 10:10:10',
+                        'startDate' => '2017-01-01T10:10:10+0000',
                     ],
                     'friends'    => [],
                 ],
@@ -271,7 +272,7 @@ class TransformToJsonCest
                 'pigLatin'   => 'Ymay amenay isyay Aulpay',
                 'occupation' => [
                     'name'      => 'Real estate novelist',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],
@@ -281,7 +282,7 @@ class TransformToJsonCest
                 'pigLatin'   => 'Ymay amenay isyay Ohnjay',
                 'occupation' => [
                     'name'      => 'Bartender',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],
@@ -291,7 +292,7 @@ class TransformToJsonCest
                 'pigLatin'   => 'Ymay amenay isyay Avyday',
                 'occupation' => [
                     'name'      => 'Sailor',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],
@@ -301,7 +302,7 @@ class TransformToJsonCest
                 'pigLatin'   => 'Ymay amenay isyay Elizabethyay',
                 'occupation' => [
                     'name'      => 'Waitress',
-                    'startDate' => '2017-01-01 10:10:10',
+                    'startDate' => '2017-01-01T10:10:10+0000',
                 ],
                 'friends'    => [],
             ],

--- a/tests/unit/Transformer/DateTimeIso8601TransformerCest.php
+++ b/tests/unit/Transformer/DateTimeIso8601TransformerCest.php
@@ -10,7 +10,7 @@ class DateTimeIso8601TransformerCest
     public function testTransform(UnitTester $I)
     {
         $transformer = new DateTimeIso8601Transformer();
-        $resource = new Item(new DateTime('2016-09-21 08:53:00'));
+        $resource = new Item(new DateTime('2016-09-21 08:53:00', new DateTimeZone("UTC")));
 
         $isoDateTime = $transformer->transform($resource);
 
@@ -23,7 +23,7 @@ class DateTimeIso8601TransformerCest
         $resource = new Item('2016-10-21T20:16:46.000Z');
         $dateTime = $transformer->untransform($resource);
 
-        $I->assertEquals(new Carbon('2016-10-21 20:16:46'), $dateTime);
+        $I->assertEquals(new Carbon('2016-10-21 20:16:46', new DateTimeZone("UTC")), $dateTime);
     }
 
     public function testIOSUntransform(UnitTester $I)
@@ -32,7 +32,7 @@ class DateTimeIso8601TransformerCest
         $resource = new Item('2016-01-12T17:00:00Z');
         $dateTime = $transformer->untransform($resource);
 
-        $I->assertEquals(new Carbon('2016-01-12 17:00:00'), $dateTime);
+        $I->assertEquals(new Carbon('2016-01-12 17:00:00',  new DateTimeZone("UTC")), $dateTime);
     }
 
     public function testEmptyStringTransform(UnitTester $I)


### PR DESCRIPTION
* add Object transformation
* rework tests

This should not cause any problems with existing code, but it does now allow the explicit setting of objects. The Item resource should be used for non-object transformations moving forward. I'll create some documentation next week and put a PR in for that.

https://github.com/finicprint/diaclone/pull/22 and https://github.com/finicprint/diaclone/pull/21 can be closed